### PR TITLE
Fix issue with int conversion to lower()

### DIFF
--- a/judges/base.py
+++ b/judges/base.py
@@ -36,10 +36,13 @@ class Judgment:
         """
         Post-initialization to normalize score values for consistency.
         """
-        if not isinstance(self.score, bool) and self.score.lower() in ["yes", "true", 1, "1", "good"]:
-            self.score = True
-        elif not isinstance(self.score, bool) and self.score.lower() in ["no", "false", 0, "0", "bad"]:
-            self.score = False
+        if isinstance(self.score, str):
+            if self.score.lower() in ["yes", "true", "1", "good"]:
+                self.score = True
+            elif self.score.lower() in ["no", "false", "0", "bad"]:
+                self.score = False
+        elif isinstance(self.score, int):
+            self.score = bool(self.score)
 
 
 @dataclass


### PR DESCRIPTION
Someone had sent us an error, so fixing it:

> I am also getting an error with  response_quality_evaluator = MTBenchChatBotResponseQuality(model=model)  you can see in the code that self.score is allowed to be score: bool | int | str  but then self.score is using .lower()  which is not supported for int .