### PR TITLE
Fix output variable name in ReliableCIRelevance judge

### DIFF
--- a/judges/graders/relevance.py
+++ b/judges/graders/relevance.py
@@ -55,7 +55,7 @@ class ReliableCIRelevance(BaseJudge):
         [3] Perfectly relevant: The passage is dedicated to the query and contains the exact answer.
         
         Query: {input}
-        Passage: {context}
+        Passage: {output}
         Relevance:
         """)
         reasoning, score = self._judge(


### PR DESCRIPTION
Fix #13 

MRE example now working
```python
import textwrap

from judges.graders.relevance import ReliableCIRelevance

PROMPT = "provide a one paragraph summary of artificial intelligence"

REPSPONSE_TEXT = textwrap.dedent(
    """"
    Artificial Intelligence (AI) is a branch of computer science focused on creating machines that can perform tasks requiring human-like intelligence, \nsuch as learning, reasoning, problem-solving, perception, and language understanding. It encompasses a wide range of techniques, including machine \nlearning, neural networks, and deep learning, which enable systems to recognize patterns, make decisions, and improve over time. AI is applied across \nvarious fields, from healthcare and finance to robotics and entertainment, driving innovation and efficiency. While AI presents significant \nopportunities, it also raises ethical concerns related to bias, privacy, and job displacement, necessitating careful regulation and responsible \ndevelopment."
    """
)

evaluator = ReliableCIRelevance(model="gpt-4o")

print(evaluator.judge(PROMPT, REPSPONSE_TEXT))
```

Output
```text
Judgment(score='3', reasoning='The passage provides a comprehensive summary of artificial intelligence, discussing its core aspects such as machine learning, neural networks, and applications across various domains. It also highlights both opportunities and ethical concerns associated with AI development. This aligns well with the query, which asks for a one-paragraph summary about artificial intelligence.')
```




