### PR TITLE
Loosen Version Restrictions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 description = "A small library of research-backed LLM judges"
 dependencies = [
-    "openai == 1.57.4",
+    "openai >= 1.57.4",
 ]
 readme = "README.md"
 requires-python = ">=3.10"
@@ -25,7 +25,7 @@ classifiers = [
 
 [project.optional-dependencies]
 litellm = [
-    "litellm==1.55.3",
+    "litellm>=1.55.3",
 ]
 auto = [
     "instructor==1.7.0",
@@ -33,7 +33,7 @@ auto = [
     "tenacity==9.0.0",
 ]
 dev = [
-    "openai-responses==0.11.2",
+    "openai-responses>=0.11.2",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
Would you be open to loosening these restrictions? 
This is incompatible with the dependency `smolagents[litellm,mcp,telemetry]`